### PR TITLE
Potential fix for code scanning alert no. 26: Code injection

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -46,7 +46,8 @@ jobs:
           (inputs.major && steps.dependabot-metadata.outputs.update-type == 'version-update:semver-major') 
           || (inputs.minor && steps.dependabot-metadata.outputs.update-type == 'version-update:semver-minor')
           || (inputs.patch && steps.dependabot-metadata.outputs.update-type == 'version-update:semver-patch')
-        run: gh pr merge --auto "--${{ inputs.strategy }}" "$PR_URL"
+        run: gh pr merge --auto "--$STRATEGY" "$PR_URL"
         env:
           PR_URL: ${{github.event.pull_request.html_url}}
           GH_TOKEN: ${{secrets.GITHUB_TOKEN}}
+          STRATEGY: ${{ inputs.strategy }}


### PR DESCRIPTION
Potential fix for [https://github.com/typisttech/.github/security/code-scanning/26](https://github.com/typisttech/.github/security/code-scanning/26)

Use an intermediate environment variable for `inputs.strategy` and reference it in the shell as `$STRATEGY` instead of `${{ inputs.strategy }}` inside the `run:` line.

Best minimal fix in `.github/workflows/dependabot-auto-merge.yml`:
- In the merge step (around current lines 45–53), change:
  - `run: gh pr merge --auto "--${{ inputs.strategy }}" "$PR_URL"`
  to:
  - `run: gh pr merge --auto "--$STRATEGY" "$PR_URL"`
- Add `STRATEGY: ${{ inputs.strategy }}` under that step’s `env:` block.

This preserves behavior (still produces `--merge`, `--squash`, or `--rebase`) while removing direct expression interpolation in shell command context.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
