### PR TITLE
release-drafter.yml: Update concurrency group name

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -8,7 +8,7 @@ on:
   workflow_call:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref_name }}
+  group: dot-github-${{ github.workflow }}-${{ github.ref_name }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
Avoid deadlock during `workflow_call`

Example: https://github.com/typisttech/wpry/actions/runs/24296593175